### PR TITLE
Fix GPL name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ By default, the backend is expected to run on `http://localhost:3001`. If you de
 
 ## License
 
-This project is licensed under the GNU General public license - see the [LICENSE](LICENSE) file for details. Any use of the code must include a reference to the original repository. Any components or UI elements reused in other projects must be credited in a visible way to the original authors.
+This project is licensed under the GNU General Public License - see the [LICENSE](LICENSE) file for details. Any use of the code must include a reference to the original repository. Any components or UI elements reused in other projects must be credited in a visible way to the original authors.
 
 The removal of the credit banner which appears at the top right corner of the website is strictly prohibited and constitutes a violation of the license. It must be visible at all times and should not be covered by any other element. 
 


### PR DESCRIPTION
## Summary
- fix capitalization of "GNU General Public License" in the README

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_6841aeb10e7c8329adb89c8d25647d5b