### PR TITLE
Fix dismissed banner state name

### DIFF
--- a/src/components/AnalyticsBanner.tsx
+++ b/src/components/AnalyticsBanner.tsx
@@ -4,7 +4,7 @@ import useOverlayQueryParam from '@/navigation/useOverlayQueryParam';
 import { useEffect, useState } from "react";
 
 export default function AnalyticsBanner() {
-  const [isDimissed, setIsDimissed] = useState(
+  const [isDismissed, setIsDismissed] = useState(
     localStorage.getItem("analyticsBannerDismissed") === "true"
   );
 
@@ -12,7 +12,7 @@ export default function AnalyticsBanner() {
 
   const transitionRef = useSpringRef();
 
-  const transition = useTransition(isDimissed, {
+  const transition = useTransition(isDismissed, {
     ref: transitionRef,
     keys: null,
     from: { opacity: 0, transform: "translateY(2rem)" },
@@ -22,11 +22,11 @@ export default function AnalyticsBanner() {
 
   useEffect(() => {
     transitionRef.start();
-  }, [transitionRef, isDimissed]);
+  }, [transitionRef, isDismissed]);
 
   const dismiss = () => {
     localStorage.setItem("analyticsBannerDismissed", "true");
-    setIsDimissed(true);
+    setIsDismissed(true);
   };
 
   return transition((style, item) => {


### PR DESCRIPTION
## Summary
- fix the typo `isDimissed` by renaming it to `isDismissed` in `AnalyticsBanner`

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_6841cadb63248329855dfad5ea49e8f8